### PR TITLE
Improve chord parsing and debugging

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,12 +18,15 @@ def generar(status_var: StringVar, midi_var: StringVar, texto: Text, modo_combo:
         status_var.set("Selecciona un MIDI de referencia")
         return
 
-    progresion_texto = texto.get("1.0", "end").strip()
+    progresion_texto = texto.get("1.0", "end")
+    progresion_texto = progresion_texto.replace("\n", " ")
+    progresion_texto = progresion_texto.replace("|", " ")
+    progresion_texto = progresion_texto.strip()
     if not progresion_texto:
         status_var.set("Ingresa una progresión de acordes")
         return
 
-    progresion = progresion_texto.split()
+    progresion = [p.strip() for p in progresion_texto.split() if p.strip()]
     midi_ref = Path(ruta_midi)
     output = midi_ref.with_stem(midi_ref.stem + "_montuno")
 

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -33,6 +33,9 @@ def obtener_posiciones_referencia(notes) -> List[dict]:
                 }
             )
     posiciones.sort(key=lambda x: (x["start"], x["pitch"]))
+    print(f"Notas base encontradas: {len(posiciones)}")
+    ejemplo = [(p['pitch'], p['start']) for p in posiciones[:10]]
+    print(f"Ejemplo primeros 10: {ejemplo}")
     return posiciones
 
 


### PR DESCRIPTION
## Summary
- support `|` and newline separators when reading a progression in `main.py`
- trim spaces around each chord symbol
- display debugging info in `obtener_posiciones_referencia`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687a4b72da4c8333abccc9442abb37b5