### PR TITLE
Add debug prints for MIDI note handling

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -17,21 +17,30 @@ def leer_midi_referencia(midi_path: Path):
     pm = pretty_midi.PrettyMIDI(str(midi_path))
     # use the first instrument only
     instrumento = pm.instruments[0]
-    return instrumento.notes, pm
+    # ensure notes are ordered by start time
+    notes = sorted(instrumento.notes, key=lambda n: n.start)
+    for n in notes:
+        nombre = pretty_midi.note_number_to_name(int(n.pitch))
+        print(f"{n.pitch} ({nombre})")
+    print(f"Total de notas: {len(notes)}")
+    return notes, pm
 
 
 def obtener_posiciones_referencia(notes) -> List[dict]:
     """Return pitch/start/end for the baseline notes present in the reference."""
     posiciones = []
     for n in notes:
-        if n.pitch in NOTAS_BASE:
+        pitch = int(n.pitch)
+        if pitch in [int(p) for p in NOTAS_BASE]:
             posiciones.append(
                 {
-                    "pitch": n.pitch,
+                    "pitch": pitch,
                     "start": n.start,
                     "end": n.end,
                 }
             )
+            nombre = pretty_midi.note_number_to_name(pitch)
+            print(f"Nota base {pitch} ({nombre}) inicio {n.start}")
     posiciones.sort(key=lambda x: (x["start"], x["pitch"]))
     print(f"Notas base encontradas: {len(posiciones)}")
     ejemplo = [(p['pitch'], p['start']) for p in posiciones[:10]]


### PR DESCRIPTION
## Summary
- print all notes when reading reference MIDI
- print details for each baseline note found
- ensure pitch comparisons use integers

## Testing
- `python - <<'EOF'
from pathlib import Path
import midi_utils
notes, pm = midi_utils.leer_midi_referencia(Path('tradicional_2-3.mid'))
print('Num notas devueltas', len(notes))
pos = midi_utils.obtener_posiciones_referencia(notes)
print('Num posiciones', len(pos))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687a4e2dab10833388e7fff6447f1819