### PR TITLE
Implement chord to eighth-note mapping

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,14 +19,10 @@ def generar(status_var: StringVar, midi_var: StringVar, texto: Text, modo_combo:
         return
 
     progresion_texto = texto.get("1.0", "end")
-    progresion_texto = progresion_texto.replace("\n", " ")
-    progresion_texto = progresion_texto.replace("|", " ")
-    progresion_texto = progresion_texto.strip()
-    if not progresion_texto:
+    progresion_texto = " ".join(progresion_texto.split())  # limpia espacios extra
+    if not progresion_texto.strip():
         status_var.set("Ingresa una progresión de acordes")
         return
-
-    progresion = [p.strip() for p in progresion_texto.split() if p.strip()]
     midi_ref = Path(ruta_midi)
     output = midi_ref.with_stem(midi_ref.stem + "_montuno")
 
@@ -37,7 +33,7 @@ def generar(status_var: StringVar, midi_var: StringVar, texto: Text, modo_combo:
         return
 
     try:
-        funcion(progresion, midi_ref, output)
+        funcion(progresion_texto, midi_ref, output)
         status_var.set(f"MIDI generado: {output}")
     except Exception as e:
         status_var.set(f"Error: {e}")

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -126,8 +126,53 @@ def exportar_montuno(
 # Traditional rhythmic grouping
 # ==========================================================================
 
-def generar_grupos_corchea(num_acordes: int) -> List[int]:
-    grupos = [3, 2, 4, 2]
-    while len(grupos) < num_acordes:
-        grupos += [5, 2, 4, 2]
-    return grupos[:num_acordes]
+# Pattern of eighth-note groups. The first four groups use ``PATRON_INICIAL``
+# and then ``PATRON_REPETICION`` is repeated indefinitely. Modify these lists
+# to tweak the rhythmic feel.
+PATRON_INICIAL = [3, 2, 4, 2]
+PATRON_REPETICION = [5, 2, 4, 2]
+
+
+def _iterar_patron_grupos():
+    """Yield eighth-note group lengths following the defined pattern."""
+    for g in PATRON_INICIAL:
+        yield g
+    while True:
+        for g in PATRON_REPETICION:
+            yield g
+
+
+def generar_grupos_corchea(cantidad: int) -> List[int]:
+    """Return ``cantidad`` eighth-note groups following the rhythmic pattern."""
+    gen = _iterar_patron_grupos()
+    return [next(gen) for _ in range(cantidad)]
+
+
+def procesar_progresion_en_grupos(texto: str) -> Tuple[List[str], List[int]]:
+    """Parse ``texto`` and map chords to their eighth-note groups."""
+
+    texto = " ".join(texto.strip().split())
+    segmentos = [s.strip() for s in texto.split("|") if s.strip()]
+
+    acordes: List[str] = []
+    duraciones: List[int] = []
+    gen = _iterar_patron_grupos()
+
+    for seg in segmentos:
+        ch = [c for c in seg.split() if c]
+        if len(ch) == 1:
+            g1 = next(gen)
+            g2 = next(gen)
+            acordes.append(ch[0])
+            duraciones.append(g1 + g2)
+        elif len(ch) == 2:
+            g1 = next(gen)
+            g2 = next(gen)
+            acordes.append(ch[0])
+            duraciones.append(g1)
+            acordes.append(ch[1])
+            duraciones.append(g2)
+        else:
+            raise ValueError("Se permiten uno o dos acordes entre barras")
+
+    return acordes, duraciones

--- a/modos.py
+++ b/modos.py
@@ -1,20 +1,23 @@
 """Definition of the available montuno generation modes."""
 
 from pathlib import Path
-from typing import List
+
 
 from voicings import generar_voicings_enlazados_tradicional
-from midi_utils import exportar_montuno, generar_grupos_corchea
+from midi_utils import (
+    exportar_montuno,
+    procesar_progresion_en_grupos,
+)
 
 
 # ==========================================================================
 # Traditional mode
 # ==========================================================================
 
-def montuno_tradicional(progresion: List[str], midi_ref: Path, output: Path) -> None:
+def montuno_tradicional(progresion_texto: str, midi_ref: Path, output: Path) -> None:
     """Generate a montuno in the traditional style."""
-    voicings = generar_voicings_enlazados_tradicional(progresion)
-    grupos_corchea = generar_grupos_corchea(len(voicings))
+    acordes, grupos_corchea = procesar_progresion_en_grupos(progresion_texto)
+    voicings = generar_voicings_enlazados_tradicional(acordes)
     exportar_montuno(midi_ref, voicings, grupos_corchea, output)
 
 


### PR DESCRIPTION
## Summary
- adjust GUI to pass raw progression text
- map chords to eighth-note groups in `midi_utils`
- update traditional mode to use new mapping

## Testing
- `python -m py_compile main.py modos.py voicings.py midi_utils.py montuno_tradicional.py`

------
https://chatgpt.com/codex/tasks/task_e_687a5b6615a48333968a60b131f4b77f