### PR TITLE
Implement eighth-note grouping logic

### DIFF
--- a/modos.py
+++ b/modos.py
@@ -16,9 +16,11 @@ from midi_utils import (
 
 def montuno_tradicional(progresion_texto: str, midi_ref: Path, output: Path) -> None:
     """Generate a montuno in the traditional style."""
-    acordes, grupos_corchea = procesar_progresion_en_grupos(progresion_texto)
+    asignaciones = procesar_progresion_en_grupos(progresion_texto)
+    acordes = [a for a, _ in asignaciones]
+    duraciones = [d for _, d in asignaciones]
     voicings = generar_voicings_enlazados_tradicional(acordes)
-    exportar_montuno(midi_ref, voicings, grupos_corchea, output)
+    exportar_montuno(midi_ref, voicings, duraciones, output)
 
 
 MODOS_DISPONIBLES = {


### PR DESCRIPTION
## Summary
- introduce PATRON_GRUPOS to define the rhythmic pattern as a single list
- rewrite `procesar_progresion_en_grupos` to return a list of `(chord, length)` and print assignments
- adjust `montuno_tradicional` to use the new interface

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails: no $DISPLAY for Tkinter)*

------
https://chatgpt.com/codex/tasks/task_e_687a655e5b7883339cda3db0b8cd4407