### PR TITLE
Remove random windows in MIDI export

### DIFF
--- a/modos.py
+++ b/modos.py
@@ -16,10 +16,10 @@ from midi_utils import (
 
 def montuno_tradicional(progresion_texto: str, midi_ref: Path, output: Path) -> None:
     """Generate a montuno in the traditional style."""
-    asignaciones = procesar_progresion_en_grupos(progresion_texto)
+    asignaciones, compases = procesar_progresion_en_grupos(progresion_texto)
     acordes = [a for a, _ in asignaciones]
     voicings = generar_voicings_enlazados_tradicional(acordes)
-    exportar_montuno(midi_ref, voicings, asignaciones, output)
+    exportar_montuno(midi_ref, voicings, asignaciones, compases, output)
 
 
 MODOS_DISPONIBLES = {


### PR DESCRIPTION
## Summary
- eliminate window-based note extraction
- iterate over the reference MIDI sequentially when constructing note positions
- fix `procesar_progresion_en_grupos` to report the number of bars
- update traditional mode to pass bar count to the exporter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from pathlib import Path
from modos import montuno_tradicional
montuno_tradicional('C7|F7', Path('tradicional_2-3.mid'), Path('out.mid'))
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687a8926efe483339ac214835794ea09