### PR TITLE
Add harmonization dropdown with octave duplication

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,9 @@ from tkinter import Tk, Text, Button, Label, filedialog, StringVar, ttk
 
 from modos import MODOS_DISPONIBLES
 
+# Opciones de armonización disponibles
+ARMONIZACIONES = ["Octavas", "Doble octava", "Terceras", "Sextas"]
+
 
 def seleccionar_midi(var: StringVar):
     path = filedialog.askopenfilename(title="MIDI de referencia", filetypes=[("MIDI files", "*.mid"), ("All files", "*.*")])
@@ -12,7 +15,13 @@ def seleccionar_midi(var: StringVar):
         var.set(path)
 
 
-def generar(status_var: StringVar, midi_var: StringVar, texto: Text, modo_combo: ttk.Combobox):
+def generar(
+    status_var: StringVar,
+    midi_var: StringVar,
+    texto: Text,
+    modo_combo: ttk.Combobox,
+    armon_combo: ttk.Combobox,
+) -> None:
     ruta_midi = midi_var.get()
     if not ruta_midi:
         status_var.set("Selecciona un MIDI de referencia")
@@ -32,8 +41,10 @@ def generar(status_var: StringVar, midi_var: StringVar, texto: Text, modo_combo:
         status_var.set(f"Modo no soportado: {modo_nombre}")
         return
 
+    armonizacion = armon_combo.get()
+
     try:
-        funcion(progresion_texto, midi_ref, output)
+        funcion(progresion_texto, midi_ref, output, armonizacion)
         status_var.set(f"MIDI generado: {output}")
     except Exception as e:
         status_var.set(f"Error: {e}")
@@ -58,7 +69,16 @@ def main():
     modo_combo.current(0)
     modo_combo.pack(fill="x", padx=5)
 
-    Button(root, text="Generar", command=lambda: generar(status_var, midi_var, texto, modo_combo)).pack(pady=10)
+    Label(root, text="Armonización:").pack(anchor="w", pady=(10, 0))
+    armon_combo = ttk.Combobox(root, values=ARMONIZACIONES)
+    armon_combo.current(0)
+    armon_combo.pack(fill="x", padx=5)
+
+    Button(
+        root,
+        text="Generar",
+        command=lambda: generar(status_var, midi_var, texto, modo_combo, armon_combo),
+    ).pack(pady=10)
     Label(root, textvariable=status_var).pack(pady=(5, 0))
 
     root.mainloop()

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -142,6 +142,37 @@ def aplicar_voicings_a_referencia(
     return nuevas_notas, max_idx
 
 
+def aplicar_armonizacion(notas: List[pretty_midi.Note], opcion: str) -> List[pretty_midi.Note]:
+    """Apply the selected harmonization option to the list of notes."""
+
+    resultado: List[pretty_midi.Note] = []
+    if opcion.lower() == "octavas":
+        # Duplicate each note one octave above
+        for n in notas:
+            resultado.append(n)
+            if n.pitch > 0:
+                resultado.append(
+                    pretty_midi.Note(
+                        velocity=n.velocity,
+                        pitch=n.pitch + 12,
+                        start=n.start,
+                        end=n.end,
+                    )
+                )
+        return resultado
+    elif opcion.lower() == "doble octava":
+        # TODO: implementar lógica para duplicar dos octavas por encima
+        pass
+    elif opcion.lower() == "terceras":
+        # TODO: implementar duplicación a la tercera
+        pass
+    elif opcion.lower() == "sextas":
+        # TODO: implementar duplicación a la sexta
+        pass
+
+    return notas
+
+
 def _grid_and_bpm(pm: pretty_midi.PrettyMIDI) -> Tuple[int, float, float]:
     """Return total number of eighth notes, duration of an eighth and bpm."""
     total = pm.get_end_time()
@@ -158,13 +189,15 @@ def exportar_montuno(
     asignaciones: List[Tuple[str, List[int]]],
     num_compases: int,
     output_path: Path,
+    armonizacion: str | None = None,
     *,
     debug: bool = False,
 ) -> None:
     """Generate a new MIDI file with the given voicings.
 
-    The resulting notes are trimmed so the output stops after the
-    last eighth-note of the progression.
+    The resulting notes are trimmed so the output stops after the last
+    eighth-note of the progression.  ``armonizacion`` indica si las notas se
+    deben duplicar (por ejemplo, en octavas).
     """
     notes, pm = leer_midi_referencia(midi_referencia_path)
     posiciones_base = obtener_posiciones_referencia(notes)
@@ -198,6 +231,12 @@ def exportar_montuno(
                 end=limite,
             )
         )
+
+    # --------------------------------------------------------------
+    # Apply harmonization (e.g. duplicate notes an octave above)
+    # --------------------------------------------------------------
+    if armonizacion:
+        nuevas_notas = aplicar_armonizacion(nuevas_notas, armonizacion)
 
     pm_out = pretty_midi.PrettyMIDI(initial_tempo=bpm)
     inst_out = pretty_midi.Instrument(

--- a/modos.py
+++ b/modos.py
@@ -14,12 +14,28 @@ from midi_utils import (
 # Traditional mode
 # ==========================================================================
 
-def montuno_tradicional(progresion_texto: str, midi_ref: Path, output: Path) -> None:
-    """Generate a montuno in the traditional style."""
+def montuno_tradicional(
+    progresion_texto: str,
+    midi_ref: Path,
+    output: Path,
+    armonizacion: str | None = None,
+) -> None:
+    """Generate a montuno in the traditional style.
+
+    ``armonizacion`` especifica la forma de duplicar las notas generadas. Por
+    ahora solo se aplica la opción "Octavas".
+    """
     asignaciones, compases = procesar_progresion_en_grupos(progresion_texto)
     acordes = [a for a, _ in asignaciones]
     voicings = generar_voicings_enlazados_tradicional(acordes)
-    exportar_montuno(midi_ref, voicings, asignaciones, compases, output)
+    exportar_montuno(
+        midi_ref,
+        voicings,
+        asignaciones,
+        compases,
+        output,
+        armonizacion=armonizacion,
+    )
 
 
 MODOS_DISPONIBLES = {


### PR DESCRIPTION
## Summary
- add harmonization dropdown in the UI
- implement octave harmonization in MIDI export
- plumb the selected option through traditional mode

## Testing
- `python -m py_compile main.py modos.py midi_utils.py voicings.py`

------
https://chatgpt.com/codex/tasks/task_e_687a929518748333a3aa9cb25d083b35