### PR TITLE
Add clave selection for montuno generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,19 +1,14 @@
 """Simple GUI for montuno generation."""
 
 from pathlib import Path
-from tkinter import Tk, Text, Button, Label, filedialog, StringVar, ttk
+from tkinter import Tk, Text, Button, Label, StringVar, ttk, Radiobutton
+
+from midi_utils import configurar_clave
 
 from modos import MODOS_DISPONIBLES
 
 # Opciones de armonización disponibles
 ARMONIZACIONES = ["Octavas", "Doble octava", "Terceras", "Sextas"]
-
-
-def seleccionar_midi(var: StringVar):
-    path = filedialog.askopenfilename(title="MIDI de referencia", filetypes=[("MIDI files", "*.mid"), ("All files", "*.*")])
-    if path:
-        var.set(path)
-
 
 def generar(
     status_var: StringVar,
@@ -23,9 +18,6 @@ def generar(
     armon_combo: ttk.Combobox,
 ) -> None:
     ruta_midi = midi_var.get()
-    if not ruta_midi:
-        status_var.set("Selecciona un MIDI de referencia")
-        return
 
     progresion_texto = texto.get("1.0", "end")
     progresion_texto = " ".join(progresion_texto.split())  # limpia espacios extra
@@ -55,13 +47,34 @@ def main():
     root.title("Generador de Montunos")
 
     midi_var = StringVar()
+    clave_var = StringVar(value="2-3")
     status_var = StringVar()
 
     Label(root, text="Progresión de acordes:").pack(anchor="w")
     texto = Text(root, width=40, height=4)
     texto.pack(fill="x", padx=5)
 
-    Button(root, text="Seleccionar MIDI", command=lambda: seleccionar_midi(midi_var)).pack(pady=5)
+    def actualizar():
+        ruta = configurar_clave(clave_var.get())
+        midi_var.set(str(ruta))
+
+    actualizar()
+
+    Label(root, text="Clave:").pack(anchor="w", pady=(5, 0))
+    Radiobutton(
+        root,
+        text="Clave 2-3",
+        variable=clave_var,
+        value="2-3",
+        command=actualizar,
+    ).pack(anchor="w")
+    Radiobutton(
+        root,
+        text="Clave 3-2",
+        variable=clave_var,
+        value="3-2",
+        command=actualizar,
+    ).pack(anchor="w")
     Label(root, textvariable=midi_var).pack()
 
     Label(root, text="Modo:").pack(anchor="w", pady=(10, 0))

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -365,12 +365,45 @@ def exportar_montuno(
 # Rhythmic pattern configuration
 # ---------------------------------------------------------------------------
 # ``PRIMER_BLOQUE`` y ``PATRON_REPETIDO`` definen el esquema de agrupación de
-# corcheas utilizado por el modo tradicional.  El primer bloque se utiliza tal
-# cual una única vez y a partir de entonces se repite ``PATRON_REPETIDO`` de
-# forma indefinida.  Para cambiar el patrón basta con modificar estas dos
-# listas.
-PRIMER_BLOQUE: List[int] = [3, 4, 4, 3]
-PATRON_REPETIDO: List[int] = [5, 4, 4, 3]
+# corcheas utilizado por el modo tradicional.
+
+# ---------------------------------------------------------------------------
+# Clave configuration
+# ---------------------------------------------------------------------------
+# Cada clave contiene el nombre del archivo MIDI de referencia y las listas
+# ``primer_bloque`` y ``patron_repetido``.  Para añadir nuevos tipos de clave
+# simplemente agrega una nueva entrada al diccionario ``CLAVES``.
+CLAVES = {
+    "2-3": {
+        "midi": Path("tradicional_2-3.mid"),
+        "primer_bloque": [3, 4, 4, 3],
+        "patron_repetido": [5, 4, 4, 3],
+    },
+    "3-2": {
+        "midi": Path("tradicional_3-2.mid"),
+        "primer_bloque": [3, 3, 5, 4],
+        "patron_repetido": [4, 3, 5, 4],
+    },
+}
+
+CLAVE_ACTUAL = "2-3"
+MIDI_REFERENCIA = CLAVES[CLAVE_ACTUAL]["midi"]
+PRIMER_BLOQUE: List[int] = CLAVES[CLAVE_ACTUAL]["primer_bloque"]
+PATRON_REPETIDO: List[int] = CLAVES[CLAVE_ACTUAL]["patron_repetido"]
+
+
+def configurar_clave(clave: str) -> Path:
+    """Selecciona ``clave`` y devuelve la ruta al MIDI correspondiente."""
+
+    global CLAVE_ACTUAL, PRIMER_BLOQUE, PATRON_REPETIDO, MIDI_REFERENCIA
+    if clave not in CLAVES:
+        raise ValueError(f"Clave desconocida: {clave}")
+    conf = CLAVES[clave]
+    CLAVE_ACTUAL = clave
+    MIDI_REFERENCIA = conf["midi"]
+    PRIMER_BLOQUE = conf["primer_bloque"]
+    PATRON_REPETIDO = conf["patron_repetido"]
+    return MIDI_REFERENCIA
 
 # ``PATRON_GRUPOS`` se mantiene solo como referencia para visualizar los
 # primeros valores calculados con la configuración actual.


### PR DESCRIPTION
## Summary
- add configurable clave patterns and MIDI references
- update GUI to select clave with radio buttons
- dynamically show reference MIDI path

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab6969d388333a9efd8c1b7d4b354