### PR TITLE
Fix NameError in interval-based harmonization

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import List, Tuple
 import pretty_midi
-from voicings import parsear_nombre_acorde
+from voicings import parsear_nombre_acorde, INTERVALOS_TRADICIONALES
 
 # Baseline notes present in the reference MIDI to be replaced by generated voicings
 NOTAS_BASE = [55, 57, 60, 64]  # G3, A3, C4, E4


### PR DESCRIPTION
## Summary
- import `INTERVALOS_TRADICIONALES` in `midi_utils`

## Testing
- `python3 - <<'EOF'
import modos, pathlib
modos.montuno_tradicional('C7 | F7', pathlib.Path('tradicional_2-3.mid'), pathlib.Path('out.mid'), 'terceras')
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_687aea6c93e08333ae03ccf30b05763b