### PR TITLE
Fix 'terceras' mode to use tenths

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -271,7 +271,7 @@ def _arm_terceras_intervalos(
     *,
     debug: bool = False,
 ) -> List[pretty_midi.Note]:
-    """Harmonize in parallel thirds following fixed functional pairs.
+    """Harmonize in parallel tenths following fixed functional pairs.
 
     Before processing the MIDI positions each chord is analysed so every
     pitch can be labelled as fundamental, third, fifth, sixth or seventh.
@@ -282,7 +282,7 @@ def _arm_terceras_intervalos(
     * 3 → 5 (+12)
     * 5 → 7 (+12) or M7 (+12) on sixth chords
     * 6 or diminished 7 → F (+24)
-    * 7 → 9 (+12)
+    * 7 → 9 (+24)
 
     Velocity and timing from the reference are preserved verbatim.
     """
@@ -367,12 +367,12 @@ def _arm_terceras_intervalos(
         # Octave or double octave shifts are applied as required.
         # --------------------------------------------------------------
         agregada = target
-        if func == "6":
+        if func in ("6", "7"):
             agregada += 24
         else:
             agregada += 12
-            while agregada <= base:
-                agregada += 12
+        while agregada <= base:
+            agregada += 12
 
         if debug:
             print(


### PR DESCRIPTION
## Summary
- update the 'terceras' harmonization algorithm so the added voice sits a tenth above
- document the new behaviour in `midi_utils._arm_terceras_intervalos`

## Testing
- `python -m py_compile *.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_687af0fb1e788333a164d5d3d669a115