### PR TITLE
Remove voicing range limits and rename thirds harmonization

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from modos import MODOS_DISPONIBLES
 
 
 # Opciones de armonización disponibles
-ARMONIZACIONES = ["Octavas", "Doble octava", "Terceras", "Sextas"]
+ARMONIZACIONES = ["Octavas", "Doble octava", "Décimas", "Sextas"]
 
 # ---------------------------------------------------------------------------
 # Configuration of the available "claves".  Each entry defines the reference

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -200,13 +200,13 @@ def _arm_por_parejas(
     *,
     debug: bool = False,
 ) -> List[pretty_midi.Note]:
-    """Generate notes in parallel motion (thirds or sixths).
+    """Generate notes in parallel motion (décimas or sixths).
 
     Each chord ``voicing`` is walked sequentially using the eighth-note
     positions assigned to it.  ``salto`` determines the pairing pattern:
-    ``1`` produces thirds and ``2`` produces sixths.  The rhythmic
-    information (start, end and velocity) is taken from the reference
-    ``posiciones`` list.
+    ``1`` produces décimas (third + octave) and ``2`` produces sixths.
+    The rhythmic information (start, end and velocity) is taken from the
+    reference ``posiciones`` list.
     """
 
     # Map each eighth index to the corresponding voicing/chord
@@ -232,7 +232,7 @@ def _arm_por_parejas(
 
         voicing = sorted(voicings[idx_voicing])
 
-        if salto == 1:  # terceras
+        if salto == 1:  # décimas
             principal = voicing[paso % 4]
             agregada = voicing[(paso + 1) % 4] + 12
         else:  # sextas
@@ -263,7 +263,7 @@ def _arm_por_parejas(
     return resultado
 
 
-def _arm_terceras_intervalos(
+def _arm_decimas_intervalos(
     posiciones: List[dict],
     voicings: List[List[int]],
     asignaciones: List[Tuple[str, List[int]]],
@@ -500,8 +500,8 @@ def exportar_montuno(
     limite = total_dest_cor * grid
 
     arm = (armonizacion or "").lower()
-    if arm == "terceras":
-        nuevas_notas = _arm_terceras_intervalos(
+    if arm == "décimas":
+        nuevas_notas = _arm_decimas_intervalos(
             posiciones, voicings, asignaciones, grid, debug=debug
         )
     elif arm == "sextas":
@@ -534,7 +534,7 @@ def exportar_montuno(
             )
         )
 
-    if arm and arm not in ("terceras", "sextas"):
+    if arm and arm not in ("décimas", "sextas"):
         nuevas_notas = aplicar_armonizacion(nuevas_notas, armonizacion)
 
     pm_out = pretty_midi.PrettyMIDI(initial_tempo=bpm)

--- a/voicings.py
+++ b/voicings.py
@@ -56,16 +56,8 @@ def parsear_nombre_acorde(nombre: str) -> Tuple[int, str]:
     return NOTAS[root], suf
 
 
-RANGO_MIN = 53  # F3
-RANGO_MAX = 67  # G4
-
-
 def _ajustar_octava(pitch: int) -> int:
-    """Move ``pitch`` by octaves so it falls inside ``RANGO_MIN``-``RANGO_MAX``."""
-    while pitch < RANGO_MIN:
-        pitch += 12
-    while pitch > RANGO_MAX:
-        pitch -= 12
+    """Return ``pitch`` unchanged (legacy helper)."""
     return pitch
 
 
@@ -86,13 +78,9 @@ def generar_voicings_enlazados_tradicional(progresion: List[str]) -> List[List[i
     bajo_anterior = referencia[0]
 
     def ajustar(pc: int, target: int) -> int:
-        """Return ``pc`` adjusted near ``target`` within range."""
+        """Return ``pc`` adjusted near ``target`` without range limits."""
         pitch = target + ((pc - target) % 12)
         if abs(pitch - target) > abs(pitch - 12 - target):
-            pitch -= 12
-        while pitch < RANGO_MIN:
-            pitch += 12
-        while pitch > RANGO_MAX:
             pitch -= 12
         return pitch
 


### PR DESCRIPTION
## Summary
- drop `RANGO_MIN`/`RANGO_MAX` limits and keep `_ajustar_octava` as identity
- adjust the voicing helper `ajustar` to no longer clamp by range
- rename "Terceras" harmonization to "Décimas"
- update GUI options accordingly
- rename `_arm_terceras_intervalos` to `_arm_decimas_intervalos`
- treat décimas as the special harmonization mode in MIDI export

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687af27e42108333b8453ade1d089f60