### PR TITLE
Fix treceavas interval calculation

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -454,24 +454,33 @@ def _arm_treceavas_intervalos(
         is_dim7 = datos["is_dim7"]
 
         pc = base % 12
+        func = None
         base_int = None
         if pc == (root_pc + ints[0]) % 12:
+            func = "F"
             base_int = ints[0]
             target_int = ints[1]
         elif pc == (root_pc + ints[1]) % 12:
+            func = "3"
             base_int = ints[1]
             target_int = ints[2]
         elif pc == (root_pc + ints[2]) % 12:
+            func = "5"
             base_int = ints[2]
             target_int = 11 if is_sixth else ints[3]
         elif pc == (root_pc + ints[3]) % 12:
             base_int = ints[3]
-            target_int = ints[0] if (is_sixth or is_dim7) else 2
+            if is_sixth or is_dim7:
+                func = "6"
+                target_int = ints[0]
+            else:
+                func = "7"
+                target_int = 2
         else:
             base_int = pc
             target_int = pc
 
-        diff = (target_int - base_int) + (24 if (is_sixth or is_dim7) else 12)
+        diff = (target_int - base_int) + (24 if func in ("6", "7") else 12)
         agregada = base + diff
 
         principal = base + 12


### PR DESCRIPTION
## Summary
- fix interval logic of `_arm_treceavas_intervalos` so that the lower note is always a 13th below the upper note

## Testing
- `python -m py_compile *.py`
- `python - <<'PY'
import pretty_midi
from midi_utils import _arm_treceavas_intervalos
posiciones=[{"pitch":60,"start":0.0,"end":0.5,"velocity":100}]
voicings=[[60,63,66,69]]
notas=_arm_treceavas_intervalos(posiciones,voicings,[('Cº7',[0])],0.5,debug=True)
print('Diff:',notas[0].pitch-notas[1].pitch)
PY`

------
https://chatgpt.com/codex/tasks/task_e_687afc399ab88333908dcb2c5f7be1fb