### PR TITLE
Implement per-chord harmonization notation

### DIFF
--- a/instrucciones.txt
+++ b/instrucciones.txt
@@ -10,4 +10,11 @@ Haz lo siguiente:
 - Que todo quede modular y fácil de extender para más modos en el futuro
 - Solo implementa el modo tradicional por ahora, pero deja comentarios para agregar más modos después
 
+Convenciones de armonización dentro de la progresión:
+  - "(8)"  activa octavas
+  - "(15)" activa doble octava
+  - "(10)" activa décimas
+  - "(13)" activa treceavas
+Puedes combinarlas en un mismo texto y el cambio se aplicará a los acordes que sigan.
+
 Organiza y comenta el código para que sea claro, limpio y mantenible.

--- a/main.py
+++ b/main.py
@@ -8,7 +8,8 @@ import midi_utils
 from modos import MODOS_DISPONIBLES
 
 
-# Opciones de armonización disponibles
+# Opciones de armonización disponibles.  También se pueden alternar dentro
+# de la progresión escribiendo "(8)", "(15)", "(10)" o "(13)" antes del acorde.
 ARMONIZACIONES = ["Octavas", "Doble octava", "Décimas", "Treceavas"]
 
 # ---------------------------------------------------------------------------

--- a/modos.py
+++ b/modos.py
@@ -25,8 +25,10 @@ def montuno_tradicional(
     ``armonizacion`` especifica la forma de duplicar las notas generadas. Por
     ahora solo se aplica la opción "Octavas".
     """
-    asignaciones, compases = procesar_progresion_en_grupos(progresion_texto)
-    acordes = [a for a, _ in asignaciones]
+    asignaciones, compases = procesar_progresion_en_grupos(
+        progresion_texto, armonizacion
+    )
+    acordes = [a for a, _, _ in asignaciones]
     voicings = generar_voicings_enlazados_tradicional(acordes)
     exportar_montuno(
         midi_ref,


### PR DESCRIPTION
## Summary
- allow specifying harmonisation changes in the chord progression
- handle markers `(8)`, `(15)`, `(10)` and `(13)` for Octavas, Doble octava, Décimas and Treceavas
- generate mixed harmonisations in MIDI output
- document new markers and hint at usage in GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import midi_utils
texto="(8)Bb6|Gm7|Cm7|F7|(15)Ebm7|Ab7|Db6|F7|(10)Bb6|Gm7|Cm7|F7|(13)Ebm7|Ab7|Db6|F7|"
res, comp = midi_utils.procesar_progresion_en_grupos(texto, "Octavas")
print('comp', comp)
for r in res[:5]:
    print(r)
print('total', len(res))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687aff5d55dc8333bc07551e8560249f