### PR TITLE
Fix missing variable in generar_notas_mixtas

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -435,6 +435,9 @@ def _arm_treceavas_intervalos(
         )
 
     contadores: dict[int, int] = {}
+    offsets: dict[int, int] = {}
+    bajo_anterior: int | None = None
+    arm_anterior: str | None = None
     resultado: List[pretty_midi.Note] = []
 
     for pos in posiciones:


### PR DESCRIPTION
## Summary
- initialize `offsets`, `bajo_anterior` and `arm_anterior` in `generar_notas_mixtas`

## Testing
- `python -m py_compile midi_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687b0440d5c48333b6fd4d951478d267