### PR TITLE
Fix undefined variable in generar_notas_mixtas

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -574,6 +574,9 @@ def generar_notas_mixtas(
         )
 
     contadores: dict[int, int] = {}
+    offsets: dict[int, int] = {}
+    bajo_anterior: int | None = None
+    arm_anterior: str | None = None
     resultado: List[pretty_midi.Note] = []
 
     for pos in posiciones:


### PR DESCRIPTION
## Summary
- define `offsets`, `bajo_anterior` and `arm_anterior` in `generar_notas_mixtas`

## Testing
- `python -m py_compile midi_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687b05dbbe548333820b015ceee0fd7c