### PR TITLE
Add support for 7(b9) chords

### DIFF
--- a/midi_utils.py
+++ b/midi_utils.py
@@ -311,6 +311,7 @@ def _arm_decimas_intervalos(
                 "intervals": ints,
                 "is_sixth": is_sixth,
                 "is_dim7": is_dim7,
+                "suf": suf,
             }
         )
 
@@ -338,6 +339,7 @@ def _arm_decimas_intervalos(
         ints = datos["intervals"]
         is_sixth = datos["is_sixth"]
         is_dim7 = datos["is_dim7"]
+        suf = datos["suf"]
 
         # --------------------------------------------------------------
         # Identify the function of ``base`` comparing its pitch class
@@ -365,7 +367,9 @@ def _arm_decimas_intervalos(
                 target_int = ints[0]
             else:
                 func = "7"
-                target_int = 2
+                # For chords 7(b9) the added note for the minor seventh
+                # is always the flat nine instead of the major nine.
+                target_int = ints[4] if suf == "7(b9)" else 2
         else:
             base_int = pc
             target_int = pc
@@ -431,6 +435,7 @@ def _arm_treceavas_intervalos(
                 "intervals": ints,
                 "is_sixth": is_sixth,
                 "is_dim7": is_dim7,
+                "suf": suf,
             }
         )
 
@@ -481,7 +486,9 @@ def _arm_treceavas_intervalos(
                 target_int = ints[0]
             else:
                 func = "7"
-                target_int = 2
+                # En acordes 7(b9) la séptima menor se empareja
+                # siempre con la novena bemol.
+                target_int = ints[4] if suf == "7(b9)" else 2
         else:
             base_int = pc
             target_int = pc
@@ -570,6 +577,7 @@ def generar_notas_mixtas(
                 "intervals": ints,
                 "is_sixth": is_sixth,
                 "is_dim7": is_dim7,
+                "suf": suf,
             }
         )
 
@@ -599,6 +607,7 @@ def generar_notas_mixtas(
             ints = datos["intervals"]
             is_sixth = datos["is_sixth"]
             is_dim7 = datos["is_dim7"]
+            suf = datos["suf"]
 
             pc = base % 12
             if pc == (root_pc + ints[0]) % 12:
@@ -619,7 +628,8 @@ def generar_notas_mixtas(
                     target_int = ints[0]
                     func = "6"
                 else:
-                    target_int = 2
+                    # En acordes 7(b9) la séptima menor se asocia a la b9
+                    target_int = ints[4] if suf == "7(b9)" else 2
                     func = "7"
             else:
                 base_int = pc

--- a/montuno_tradicional.py
+++ b/montuno_tradicional.py
@@ -19,6 +19,7 @@ INTERVALOS_TRADICIONALES = {
     'º∆':     [0, 3, 6, 11],    # 1 b3 b5 7
     'ø':      [0, 3, 6, 10],    # 1 b3 b5 b7
     '7(b5)':  [0, 4, 6, 10],    # 1 3 b5 b7
+    '7(b9)':  [0, 4, 7, 10, 13], # 1 3 5 b7 b9
     '∆(b5)':  [0, 4, 6, 11],    # 1 3 b5 7
 }
 
@@ -41,7 +42,10 @@ NOTAS = {
 
 def parsear_nombre_acorde(nombre):
     import re
-    m = re.match(r'^([A-G][b#]?)(m6|m7|m∆|m|6|7|∆sus4|∆sus2|∆|\+7|º7|º∆|ø|7sus4|7sus2|7\(b5\)|∆\(b5\))$', nombre)
+    m = re.match(
+        r'^([A-G][b#]?)(m6|m7|m∆|m|6|7|∆sus4|∆sus2|∆|\+7|º7|º∆|ø|7sus4|7sus2|7\(b5\)|7\(b9\)|∆\(b5\))$',
+        nombre,
+    )
     if not m:
         raise ValueError(f"Acorde no reconocido: {nombre}")
     root, suf = m.group(1), m.group(2)

--- a/voicings.py
+++ b/voicings.py
@@ -32,6 +32,7 @@ INTERVALOS_TRADICIONALES = {
     'º∆':     [0, 3, 6, 11],    # 1 b3 b5 7
     'ø':      [0, 3, 6, 10],    # 1 b3 b5 b7
     '7(b5)':  [0, 4, 6, 10],    # 1 3 b5 b7
+    '7(b9)':  [0, 4, 7, 10, 13],  # 1 3 5 b7 b9
     '∆(b5)':  [0, 4, 6, 11],    # 1 3 b5 7
 }
 
@@ -58,7 +59,10 @@ def parsear_nombre_acorde(nombre: str) -> Tuple[int, str]:
     """Parse a chord name into root MIDI pitch class and suffix."""
     import re
 
-    m = re.match(r'^([A-G][b#]?)(m6|m7|m∆|m|6|7|∆sus4|∆sus2|∆|\+7|º7|º∆|ø|7sus4|7sus2|7\(b5\)|∆\(b5\))$', nombre)
+    m = re.match(
+        r'^([A-G][b#]?)(m6|m7|m∆|m|6|7|∆sus4|∆sus2|∆|\+7|º7|º∆|ø|7sus4|7sus2|7\(b5\)|7\(b9\)|∆\(b5\))$',
+        nombre,
+    )
     if not m:
         raise ValueError(f"Acorde no reconocido: {nombre}")
     root, suf = m.group(1), m.group(2)


### PR DESCRIPTION
## Summary
- extend chord dictionary to include `7(b9)`
- update chord parser regexes
- handle `7(b9)` when pairing tenths and thirteenths using the b9

## Testing
- `python -m py_compile main.py modos.py voicings.py midi_utils.py montuno_tradicional.py`
- `python - <<'PY'
import voicings
print(voicings.parsear_nombre_acorde('C7(b9)'))
print(voicings.INTERVALOS_TRADICIONALES['7(b9)'])
PY`
- `python - <<'PY'
from midi_utils import _arm_decimas_intervalos
pos=[{'pitch':55,'start':0.0,'end':0.5,'velocity':100}]
voi=[[60,64,67,70]]
print([(n.pitch,n.start,n.end) for n in _arm_decimas_intervalos(pos,voi,[('C7(b9)',[0])],0.5)])
PY`
- `python - <<'PY'
from midi_utils import generar_notas_mixtas
pos=[{'pitch':55,'start':0,'end':0.5,'velocity':90}]
voi=[[55,59,62,65]]
print([n.pitch for n in generar_notas_mixtas(pos,voi,[('C7(b9)',[0],'Décimas')],0.5)])
PY`


------
https://chatgpt.com/codex/tasks/task_e_687bab50c0648333a48be148f97a0025